### PR TITLE
Abstract out common components into a centralized directory

### DIFF
--- a/src/components/common/image/ImageAttribution.tsx
+++ b/src/components/common/image/ImageAttribution.tsx
@@ -1,0 +1,16 @@
+interface ImageAttributionProps {
+  photographer: string;
+  source?: string;
+}
+
+export function ImageAttribution({
+  photographer,
+  source = "via Unsplash",
+}: ImageAttributionProps) {
+  return (
+    <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white opacity-0 group-hover:opacity-100 transition-opacity z-10">
+      <p className="text-xs font-medium">Photo by {photographer}</p>
+      <p className="text-[10px] text-gray-300">{source}</p>
+    </div>
+  );
+}

--- a/src/components/common/image/ImageDisplay.tsx
+++ b/src/components/common/image/ImageDisplay.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+interface ImageDisplayProps {
+  src: string;
+  alt: string;
+  priority?: boolean;
+  className?: string;
+}
+
+export function ImageDisplay({
+  src,
+  alt,
+  priority = false,
+  className,
+}: ImageDisplayProps) {
+  return (
+    <div className={cn(
+      "relative aspect-square w-full rounded-lg overflow-hidden bg-muted",
+      className
+    )}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        className="object-cover"
+        priority={priority}
+      />
+    </div>
+  );
+}

--- a/src/components/game/PromptConsole/ResultView.tsx
+++ b/src/components/game/PromptConsole/ResultView.tsx
@@ -2,8 +2,8 @@
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import Image from "next/image";
 import type { ResultViewProps } from "./PromptConsole.types";
+import { ImageDisplay } from "@/components/common/image/ImageDisplay";
 
 export function ResultView({ result, onReset }: ResultViewProps) {
   return (
@@ -13,14 +13,7 @@ export function ResultView({ result, onReset }: ResultViewProps) {
         <p className="text-muted-foreground">Here is the AI result:</p>
       </div>
       <Card className="p-4 border-2 border-primary/20 overflow-hidden space-y-4">
-        <div className="relative aspect-square w-full rounded-lg overflow-hidden bg-muted">
-          <Image
-            src={result.imageUrl}
-            alt="AI Generation"
-            fill
-            className="object-cover"
-          />
-        </div>
+        <ImageDisplay src={result.imageUrl} alt="AI Generation" />
         <div className="flex items-center justify-between">
           <div className="text-sm font-medium text-muted-foreground">
             Similarity Score

--- a/src/components/game/TargetViewer/TargetView.tsx
+++ b/src/components/game/TargetViewer/TargetView.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { ImageAttribution } from "@/components/common/image/ImageAttribution";
+import { ImageDisplay } from "@/components/common/image/ImageDisplay";
 
 interface TargetViewerProps {
   imageUrl: string;
@@ -9,17 +11,12 @@ interface TargetViewerProps {
 
 export function TargetViewer({ imageUrl, photographer }: TargetViewerProps) {
   return (
-    <Card className="relative overflow-hidden aspect-square h-full max-h-[600px] group border-border/50">
-      <div className="relative w-full h-full">
-        {/* Priority=true tells Next.js to load this image immediately */}
-        <Image
-          src={imageUrl}
-          alt="Target to replicate"
-          fill
-          className="object-cover"
-          priority
-        />
-      </div>
+    <Card className="relative overflow-hidden aspect-square h-full max-h-[600px] group border-border/50 p-0">
+      <ImageDisplay
+        src={imageUrl}
+        alt="Target to replicate"
+        priority
+      />
 
       {/* Overlay Info */}
       <div className="absolute top-4 left-4">
@@ -31,11 +28,8 @@ export function TargetViewer({ imageUrl, photographer }: TargetViewerProps) {
         </Badge>
       </div>
 
-      {/* Photographer Credit (Fades in on hover) */}
-      <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white opacity-0 group-hover:opacity-100 transition-opacity">
-        <p className="text-xs font-medium">Photo by {photographer}</p>
-        <p className="text-[10px] text-gray-300">via Unsplash</p>
-      </div>
+      {/* Photographer Credit */}
+      <ImageAttribution photographer={photographer} />
     </Card>
   );
 }


### PR DESCRIPTION
Created a `src/components/common` to house commonly used components for better reusabiltiy. 

Currently this directory houses Image Attribution and Image Display component to comply with Unsplash's policy. We'll update Image Attribution component in a future ticket, but wanted to start the refactor

