### PR TITLE
move dependabot yml to the .github/ directory

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,8 +1,0 @@
-# Dependabot action for auto checking for upates to github acitons
-# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
move dependabot yml file to `.github/` top level directory

i initially put it under `.github/workflows`, but dependabot yml is NOT a github action