### PR TITLE
Github Action to deploy promptle to vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Promptle Production Deploy
+
+# Github Action to manually deploy Promptle to Vercel. This is to ensure
+# safe, controlled release of features.
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Context

We have done a successful release of Promptle which is a dummy frontend and none of the backend wired up. I went through the integration manually, but noticed that on merge to `main`, an auto deploy happens in Vercel. 

Since we need to wire up Promptle's backend and that's an incremental process, in order to do the release in a safe and controlled manner, we will temporarily make production deploy manual. Once the MVP is created, a followup PR will make the deploy a true CI/CD system

## Changes Made
* Created a lightweight action to manually run production deploy of Promptle via Vercel
* As we do edits on the app, each PR will automatically show a preview of the app. This is still safe because the environment is a sandbox rather than production

