### PR TITLE
trigger frontend ci on pr if src directory is modified

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -5,7 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    working-directory: ./src
+    paths:
+      - 'src/**'
 
 jobs:
   build-and-lint:


### PR DESCRIPTION
I noticed the frontend CI github aciton is triggered on every PR (eg: readme update)

we should only trigger frontend CI checks when frontend related files are modified, so we'll restrict for running the check whenever the src/* directory is modified