### PR TITLE
Add UTM tags to comply with Unsplash Attribution Guidelines

### DIFF
--- a/src/components/common/image/ImageAttribution.tsx
+++ b/src/components/common/image/ImageAttribution.tsx
@@ -1,16 +1,38 @@
+import { UNSPLASH_REFERRAL_URL } from "@/constants/image";
+
 interface ImageAttributionProps {
   photographer: string;
-  source?: string;
+  photographerUrl: string;
 }
 
 export function ImageAttribution({
   photographer,
-  source = "via Unsplash",
+  photographerUrl,
 }: ImageAttributionProps) {
   return (
     <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white opacity-0 group-hover:opacity-100 transition-opacity z-10">
-      <p className="text-xs font-medium">Photo by {photographer}</p>
-      <p className="text-[10px] text-gray-300">{source}</p>
+      <p className="text-xs font-medium">
+        Photo by{" "}
+        <a
+          href={photographerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-gray-200"
+        >
+          {photographer}
+        </a>
+      </p>
+      <p className="text-[10px] text-gray-300">
+        via{" "}
+        <a
+          href={UNSPLASH_REFERRAL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-gray-200"
+        >
+          Unsplash
+        </a>
+      </p>
     </div>
   );
 }

--- a/src/components/game/TargetViewer/TargetView.tsx
+++ b/src/components/game/TargetViewer/TargetView.tsx
@@ -9,7 +9,11 @@ interface TargetViewerProps {
   photographerUrl: string;
 }
 
-export function TargetViewer({ imageUrl, photographer, photographerUrl }: TargetViewerProps) {
+export function TargetViewer({
+  imageUrl,
+  photographer,
+  photographerUrl,
+}: TargetViewerProps) {
   return (
     <Card className="relative overflow-hidden aspect-square h-full max-h-[600px] group border-border/50 p-0">
       <ImageDisplay src={imageUrl} alt="Target to replicate" priority />
@@ -25,7 +29,10 @@ export function TargetViewer({ imageUrl, photographer, photographerUrl }: Target
       </div>
 
       {/* Photographer Credit */}
-      <ImageAttribution photographer={photographer} photographerUrl={photographerUrl} />
+      <ImageAttribution
+        photographer={photographer}
+        photographerUrl={photographerUrl}
+      />
     </Card>
   );
 }

--- a/src/components/game/TargetViewer/TargetView.tsx
+++ b/src/components/game/TargetViewer/TargetView.tsx
@@ -9,7 +9,7 @@ interface TargetViewerProps {
   photographerUrl: string;
 }
 
-export function TargetViewer({ imageUrl, photographer }: TargetViewerProps) {
+export function TargetViewer({ imageUrl, photographer, photographerUrl }: TargetViewerProps) {
   return (
     <Card className="relative overflow-hidden aspect-square h-full max-h-[600px] group border-border/50 p-0">
       <ImageDisplay src={imageUrl} alt="Target to replicate" priority />
@@ -25,7 +25,7 @@ export function TargetViewer({ imageUrl, photographer }: TargetViewerProps) {
       </div>
 
       {/* Photographer Credit */}
-      <ImageAttribution photographer={photographer} />
+      <ImageAttribution photographer={photographer} photographerUrl={photographerUrl} />
     </Card>
   );
 }

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -1,0 +1,3 @@
+export const UNSPLASH_APP_NAME = "promptle";
+
+export const UNSPLASH_REFERRAL_URL = `https://unsplash.com/?utm_source=${UNSPLASH_APP_NAME}&utm_medium=referral`;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -205,7 +205,12 @@ BEGIN
   END IF;
 END $$;
 
--- INSERT CHALLENGES
+/*
+INSERT CHALLENGES
+
+When adding photographer_profile_url, follow the attribution guideline here:
+https://help.unsplash.com/en/articles/2511315-guideline-attribution 
+*/
 INSERT INTO public.challenges (
     id, date, unsplash_id, image_url, photographer_name, photographer_profile_url, photo_description, embedding
 ) VALUES
@@ -216,7 +221,7 @@ INSERT INTO public.challenges (
       'ukvgqriuOgo',
       'https://images.unsplash.com/photo-1444723121867-7a241cacace9?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
       'Henning Witzel',
-      'https://unsplash.com/@henning',
+      'https://unsplash.com/@henning?utm_source=promptle&utm_medium=referral',
       'Los Angeles by Night',
       (SELECT array_agg((0.1 + (i::float / 1000))::float4)::vector FROM generate_series(1, 512) AS i)
     ),
@@ -227,7 +232,7 @@ INSERT INTO public.challenges (
       'GA2y1XU9bIw',
       'https://images.unsplash.com/photo-1766864109448-3cb84647b818?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzY4MTY1MTA1fA&ixlib=rb-4.1.0&q=80&w=1080',
       'Maxim Tolchinskiy',
-      'https://unsplash.com/@shaikhulud',
+      'https://unsplash.com/@shaikhulud?utm_source=promptle&utm_medium=referral',
       'Snowy park path lined with lampposts at night',
       (SELECT array_agg((0.2 + (i::float / 1000))::float4)::vector FROM generate_series(1, 512) AS i)
     ),
@@ -238,7 +243,7 @@ INSERT INTO public.challenges (
       'abcdefghijk',
       'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?q=80&w=1470&auto=format&fit=crop',
       'Future Photographer',
-      'https://unsplash.com/@future',
+      'https://unsplash.com/@future?utm_source=promptle&utm_medium=referral',
       'Mountain landscape at sunset',
       (SELECT array_agg((0.3 + (i::float / 1000))::float4)::vector FROM generate_series(1, 512) AS i)
     );


### PR DESCRIPTION
<!--                                                                                                                          
Example of a past PR: https://github.com/Promptle-Organization/promptle/pull/50                                                        
Use this as a reference for how to fill out each section.                                                                     
-->  
**Issue Link:** #57 

## Context
Currently the `challenges` table contains info about the photographer's profile URL, image URL, etc. However, we don't append the UTM tags for URLs to unsplash as per this [guideline](https://help.unsplash.com/en/articles/2511315-guideline-attribution). This PR aims to address this issue

## Changes Made
We add the UTM tags for photographer profile URL and the Unsplash URL on the database side. 

* Update the `seed.sql` script to add UTM tags for photographer profile URL column
* Update the `generate-daily-challenge` function to add UTM tags for future image challenges
* Update the `ImageAttribution` component to take in photographer profile URL and display the attribution text with clickable link

## Testing Plan
Video demo


https://github.com/user-attachments/assets/d7dccbfb-6006-4248-9b87-febb1586301b

